### PR TITLE
fix: load subitems on search

### DIFF
--- a/src/list/item/directive.js
+++ b/src/list/item/directive.js
@@ -84,7 +84,8 @@ export default /* @ngInject */ function ($compile) {
 
       self.isSearchEnabled = function isSearchEnabled() {
         if (self.item.allowSearch) {
-          if (self.item.subItemsAdded.length > self.getMinItemsForEnablingSearch()) {
+          if (self.item.subItemsAdded.length > self.getMinItemsForEnablingSearch()
+            || self.item.forceDisplaySearch) {
             return true;
           }
 


### PR DESCRIPTION
## fix: load subitems on search

### Description of the Change

* add `forceDisplaySearch` to force the search input display
* fix bug when using `onLoad` and search
* force to load subitems on search

e80de20 — fix: load subitems on search

ref: DTRUN-2021


