### PR TITLE
build(gitignore): add missing tools entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+tools


### PR DESCRIPTION
# Add missing tools entry

Useful when using internal scripts.

## :gear: Build

4887c84 - build(gitignore): add missing tools entry

## :house: Internal

- No QC required.