### PR TITLE
fix: turn label visible when displaying the error retry button

### DIFF
--- a/src/index.less
+++ b/src/index.less
@@ -211,7 +211,6 @@
 
       button.btn.btn-default {
         margin-top: 5px;
-        color: #fff;
       }
     }
 


### PR DESCRIPTION
# Turn label visible when displaying the error retry button

**Before**:
![screenshot-1](https://user-images.githubusercontent.com/428384/66917056-ea2bcb80-f01c-11e9-9597-d62381b44e8f.png)

**After**:
![screenshot-2](https://user-images.githubusercontent.com/428384/66917060-edbf5280-f01c-11e9-8649-1b6731193cf6.png)

## :bug: Bug Fix

0971b14 - fix: turn label visible when displaying the error retry button

## :link: Related

fix #89

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>